### PR TITLE
Update dockerfile to use base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
+ARG base_image
+
 FROM golang:1.13 as resource
 COPY . /resource
 WORKDIR /resource
 RUN ./build.sh
 
-FROM ubuntu:bionic
+FROM ${base_image}
 COPY --from=resource /resource/tmp/build/* /opt/resource/
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update dockerfile to use base image

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updates resource to use our hardened base image
